### PR TITLE
Implement duplicate nickname verification

### DIFF
--- a/incs/NumericReplies.hpp
+++ b/incs/NumericReplies.hpp
@@ -17,6 +17,7 @@
 #define	RPL_NAMREPLY	"353"
 #define	RPL_ENDOFNAME	"366"
 //
+#define ERR_NONICKGIVEN		"431"
 #define ERR_NICKNAMEINUSE	"433"
 #define	ERR_BANNEDFROMCHAN	"474"
 #define ERR_BADCHANNELKEY	"475"
@@ -40,6 +41,7 @@ public:
 
 	class Error {
 	public:
+		static void	noNickGiven(Client &client);
 		static void nickInUse(Client &client, const std::string &nickName);
 		static void	bannedFromChan(Client &client, const std::string &channName);
 		static void	badChannelKey(Client &client, const std::string &channName);

--- a/incs/NumericReplies.hpp
+++ b/incs/NumericReplies.hpp
@@ -17,7 +17,7 @@
 #define	RPL_NAMREPLY	"353"
 #define	RPL_ENDOFNAME	"366"
 //
-//#define ERR_NICKNAMEINUSE	"433"
+#define ERR_NICKNAMEINUSE	"433"
 #define	ERR_BANNEDFROMCHAN	"474"
 #define ERR_BADCHANNELKEY	"475"
 
@@ -40,6 +40,7 @@ public:
 
 	class Error {
 	public:
+		static void nickInUse(Client &client, const std::string &nickName);
 		static void	bannedFromChan(Client &client, const std::string &channName);
 		static void	badChannelKey(Client &client, const std::string &channName);
 	};

--- a/incs/client.hpp
+++ b/incs/client.hpp
@@ -26,6 +26,7 @@ class	Client
 
 		void	updateClientStatus(const int &epollFd);
 		void	addClientToEpoll(const int &epollFd);
+		void	sendNumericReply(const std::string &message);
 		void	addMessageToSendbox(std::string message);
 
 		//getters

--- a/incs/server.hpp
+++ b/incs/server.hpp
@@ -21,6 +21,7 @@
 typedef std::map<int, Client *> fdClientMap;
 typedef std::map<std::string, Channel *> channelMap;
 typedef std::vector<std::string> vectorCommand;
+typedef std::set<std::string> nickSet;
 
 class Channel;
 class Client;
@@ -144,15 +145,15 @@ class	Server
 
 	private:
 		std::map<std::string, Handler>	_commands;
-		std::set<std::string>	_nickUsed;
-		std::string			_password;
-		struct epoll_event	_servEpollEvent;
-		fdClientMap			_clients;
-		channelMap			_channels;
-		uint64_t			_port;
-		struct sockaddr_in	_sockaddr;
-		int					_socket;
-		int 				_epollFd;
+		nickSet							_nickUsed;
+		std::string						_password;
+		struct epoll_event				_servEpollEvent;
+		fdClientMap						_clients;
+		channelMap						_channels;
+		uint64_t						_port;
+		struct sockaddr_in				_sockaddr;
+		int								_socket;
+		int 							_epollFd;
 };
 
 vectorCommand	ParsCommand(std::string const &msg);

--- a/srcs/NumericReplies.cpp
+++ b/srcs/NumericReplies.cpp
@@ -14,7 +14,7 @@ void NumericReplies::reply::welcome(Client &client)
 			<< " Network " << client.GetUsername()
 			<< "!" + client.GetRealname()
 			<< "@localhost" << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //# define RPL_NOTOPIC(client, channel) (":localhost 331 " + client + " #" + channel + " :No topic is set\r\n")
@@ -25,7 +25,7 @@ void NumericReplies::reply::noTopic(Client &client, const std::string &channName
 			<< client.GetUsername() << " #"
 			<< channName
 			<< " :No topic is set" << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //# define RPL_TOPIC(client, channel, topic) (":localhost 332 " + client + " #" + channel + " " + topic + "\r\n")
@@ -36,7 +36,7 @@ void NumericReplies::reply::topic(Client &client, const std::string &channName, 
 			<< client.GetUsername() << " #"
 			<< channName << " "
 			<< topic << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //#define RPL_NAMREPLY(client, channel, list_of_nicks) (":localhost 353 " + client +"user = #" + channel + " :" + list_of_nicks + "\r\n")
@@ -47,7 +47,7 @@ void	NumericReplies::reply::nameInChannel(Client &client, const std::string &cha
 			<< client.GetUsername() << "user = #"
 			<< channName << " :"
 			<< allNick << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //# define RPL_ENDOFNAMES(client, channel) (":localhost 366 " + client + " #" + channel + " :End of /NAMES list.\r\n")
@@ -57,7 +57,7 @@ void	NumericReplies::reply::endOfName(Client &client, const std::string &channNa
 	reply << constructNumericReplyHeader(RPL_ENDOFNAME, SERVER_NAME)
 			<< client.GetUsername() << " #"
 			<< channName  << " :End of /NAMES list." << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 
@@ -68,7 +68,7 @@ void	NumericReplies::Error::bannedFromChan(Client &client, const std::string &ch
 	reply << constructNumericReplyHeader(ERR_BANNEDFROMCHAN, SERVER_NAME)
 			<< client.GetUsername() << " #"
 			<< channName << "  :Cannot join channel (+b)" << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " #" + channel + " :Cannot join channel (+k)\r\n")
@@ -79,14 +79,14 @@ void	NumericReplies::Error::badChannelKey(Client &client, const std::string &cha
 			<< client.GetUsername() << " #"
 			<< channName
 			<< " :Cannot join channel (+k)" << DELIMITER;
-	client.addMessageToSendbox(reply.str());
+	client.sendNumericReply(reply.str());
 }
 
 //TODO: remove this when implementing notification in respective command file
 
 // # define RPL_JOIN(user, channel) (":" + user + " JOIN #" + channel + "\r\n")
 void	NumericReplies::Notification::joinNotify(Client &client, const std::string &channName) {
-	client.addMessageToSendbox(":" + client.GetUsername() + " JOIN #" + channName + DELIMITER);
+	client.sendNumericReply(":" + client.GetUsername() + " JOIN #" + channName + DELIMITER);
 }
 
 std::string	NumericReplies::constructNumericReplyHeader(const std::string &numericID, const std::string &hostName) {

--- a/srcs/NumericReplies.cpp
+++ b/srcs/NumericReplies.cpp
@@ -60,6 +60,16 @@ void	NumericReplies::reply::endOfName(Client &client, const std::string &channNa
 	client.sendNumericReply(reply.str());
 }
 
+// 433 <nick> :Nickname is already in use"
+void	NumericReplies::Error::nickInUse(Client &client, const std::string &nickName) {
+	std::stringstream reply;
+
+	reply << constructNumericReplyHeader(ERR_NICKNAMEINUSE, SERVER_NAME)
+			<< nickName
+			<< " :" << nickName
+			<< " is already in use" << DELIMITER;
+	client.sendNumericReply(reply.str());
+}
 
 //# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " #" + channel + " :Cannot join channel (+b)\r\n")
 void	NumericReplies::Error::bannedFromChan(Client &client, const std::string &channName) {

--- a/srcs/NumericReplies.cpp
+++ b/srcs/NumericReplies.cpp
@@ -60,6 +60,16 @@ void	NumericReplies::reply::endOfName(Client &client, const std::string &channNa
 	client.sendNumericReply(reply.str());
 }
 
+//431 * :No nickname given
+void	NumericReplies::Error::noNickGiven(Client &client) {
+	std::stringstream reply;
+
+	reply << constructNumericReplyHeader(ERR_NONICKGIVEN, SERVER_NAME)
+			<<" * :No nickname given"
+			<< DELIMITER;
+	client.sendNumericReply(reply.str());
+}
+
 // 433 <nick> :Nickname is already in use"
 void	NumericReplies::Error::nickInUse(Client &client, const std::string &nickName) {
 	std::stringstream reply;

--- a/srcs/client.cpp
+++ b/srcs/client.cpp
@@ -47,6 +47,10 @@ void	Client::updateClientStatus(const int &epollFd) {
 	epoll_ctl(epollFd, EPOLL_CTL_MOD, this->_fd, &this->_clientEpollevent);
 }
 
+void Client::sendNumericReply(const std::string &message) {
+	this->_msgToSend.push(message);
+}
+
 void Client::addMessageToSendbox(std::string message) {
 	if (_password == false)
 	{

--- a/srcs/commands/Join.cpp
+++ b/srcs/commands/Join.cpp
@@ -41,6 +41,7 @@ client->updateClientStatus(_epollFd);
 	stringClientMap	ClientChannel = _channels[RealNameChannel]->GetClients();
 //	client->addMessageToSendbox(RPL_JOIN(client->GetUsername(), RealNameChannel));
 	NumericReplies::Notification::joinNotify(*client, RealNameChannel);
+	client->updateClientStatus(this->_epollFd);
 	for (stringClientMap::iterator it = ClientChannel.begin(); it != ClientChannel.end(); it++)
 	{
 		if (this->_clients.find(it->second) != _clients.end())

--- a/srcs/commands/Join.cpp
+++ b/srcs/commands/Join.cpp
@@ -14,6 +14,7 @@ void Server::join(vectorCommand args, Client *client)
 	// 	std::cout << "invalid number of args" << std::endl;
 	// 	return (false);
 	// }
+	//TODO: Clarifier avec Alex
 	if (args[1].find("#") != 0)
 	{
 		client->addMessageToSendbox(":irc.localhost 471 " + client->GetUsername() + " #" + args[1] + " :Cannot join channel\r\n");

--- a/srcs/commands/Nick.cpp
+++ b/srcs/commands/Nick.cpp
@@ -6,6 +6,14 @@
 
 void Server::nick(vectorCommand args, Client *client)
 {
+	if (this->_nickUsed.find(args[1]) != this->_nickUsed.end()) {
+		NumericReplies::Error::nickInUse(*client, args[1]);
+		client->updateClientStatus(this->_epollFd);
+		throw NickAlreadyExist();
+	}
+	if (!client->GetNickname().empty())
+		this->_nickUsed.erase(client->GetNickname());
+	this->_nickUsed.insert(args[1]);
 	client->SetNickname(args[1]);
 	std::cout << client->GetNickname() << " " << client->GetUsername() << " " << client->GetFd() << ": " << "have new nickname" << std::endl;
 }

--- a/srcs/commands/Nick.cpp
+++ b/srcs/commands/Nick.cpp
@@ -6,6 +6,8 @@
 
 void Server::nick(vectorCommand args, Client *client)
 {
+	if (args.size() == 1 || args[1].empty())
+		NumericReplies::Error::noNickGiven(*client);
 	if (this->_nickUsed.find(args[1]) != this->_nickUsed.end()) {
 		NumericReplies::Error::nickInUse(*client, args[1]);
 		client->updateClientStatus(this->_epollFd);

--- a/srcs/commands/Nick.cpp
+++ b/srcs/commands/Nick.cpp
@@ -4,6 +4,11 @@
 
 #include "server.hpp"
 
+
+//TODO Implement this ?
+//The NICK message may be sent from the server to clients to acknowledge their NICK command was successful,
+// and to inform other clients about the change of nickname. In these cases, the <source> of the message will be the
+// old nickname [ [ "!" user ] "@" host ] of the user who is changing their nickname.
 void Server::nick(vectorCommand args, Client *client)
 {
 	if (args.size() == 1 || args[1].empty())

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -177,7 +177,6 @@ bool	Server::HandleCommand(std::string const &msg, Client *client)
 	}
 	catch (UnableToCreateChannel &e)
 	{
-
 		std::cout << e.what() << std::endl;
 		return (false);
 	}
@@ -288,6 +287,7 @@ void Server::RemoveClient(int key)
 		std::cout << "Client to remove not found" << std::endl;
 		return;
 	}
+	this->_nickUsed.erase(toRemove->second->GetNickname());
 	for (channelMap::iterator it = _channels.begin(); it != _channels.end(); it++)
 	{
 		if (it->second->IsInChannel(toRemove->second->GetNickname()))


### PR DESCRIPTION
- Added function Client::sendNumericReply to force the sending of a NR even if the target client is not authenticate
- Added implementation of function NumericReplies::Error::nickInUse
- Added security in case of client trying to connect with a nickname already use. Server keep a set of all nickname used. When a client is removed, so is his nickname
- Added implementation and use of Numeric 431 ERR_NONICKNAMEGIVEN
- Added potential TODO
